### PR TITLE
Feature/admin messages structure

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,4 @@
 import "./App.css";
-// import { Link } from "react-router";
-// import { AdminLayout } from "./components/admin/layout/AdminLayout";
-// import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
-// import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
-// import { Outlet } from "react-router";
 import { createRoot } from "react-dom/client";
 import Main from "./main";
 

--- a/frontend/src/api/message.adapter.ts
+++ b/frontend/src/api/message.adapter.ts
@@ -1,19 +1,21 @@
+import dayjs from "dayjs";
 import type { MessageBackend, MessageUI } from "../types/message.types";
 
 export const mapMessageFromApi = (msg: MessageBackend): MessageUI => {
   return {
     id: msg.id,
-    messageScope: msg.messageScope,
+    hotelId: import.meta.env.VITE_HOTEL_ID,
+    bookingId: msg.bookingId ? msg.bookingId : null,
     title: msg.title,
     content: msg.content,
     status: msg.isActive ? "posted" : "pending",
-    postDateTime:
-      msg.postDate && msg.postTime
-        ? `Posted: ${msg.postDate} - ${msg.postDate}`
-        : null,
-    deleteDateTime:
-      msg.deleteDate && msg.deleteTime
-        ? `Posted: ${msg.deleteDate} - ${msg.deleteTime}`
-        : null,
+    postDateTime: msg.postAt
+      ? dayjs(msg.postAt).format("YYYY.MM-DD HH:mm")
+      : null,
+    expiresAtDateTime: msg.expiresAt
+      ? dayjs(msg.expiresAt).format("YYYY.MM-DD HH:mm")
+      : null,
+    isActive: msg.isActive,
+    author: msg.author,
   };
 };

--- a/frontend/src/components/admin/MessageAccordion.tsx
+++ b/frontend/src/components/admin/MessageAccordion.tsx
@@ -10,32 +10,9 @@ import {
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { theme } from "../../theme";
-import type { MessageBackend, MessageUI } from "../../types/message.types";
-import { useState } from "react";
 import type { MsgStatus } from "../../types/theme.types";
-
-
-const mockMessages: MessageUI[] = [
-  {
-    id: "1",
-    messageScope: "all",
-    title: "Muffins for breakfast",
-    content: "Today we offer muffins for breakfast at the front desk.",
-    status: "posted",
-    postDateTime: "26-01-25 - 06:00",
-    deleteDateTime: "26-01-25 - 06:00",
-  },
-  {
-    id: "2",
-    messageScope: "checkingOut",
-    title: "Thank you for your stay",
-    content:
-      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
-    status: "pending",
-    postDateTime: "26-01-25 - 06:00",
-    deleteDateTime: "26-01-25 - 10:00",
-  },
-];
+import type { MessageBackend, MessageUI } from "../../types/message.types";
+import type React from "react";
 
 const badgeStyle = (status: MsgStatus) => ({
   display: "inline-block",
@@ -52,47 +29,32 @@ const badgeStyle = (status: MsgStatus) => ({
   textTransform: "uppercase",
 });
 
-export const MessageAccordion = () => {
-  const [mockData, setMockData] = useState(mockMessages);
-  const [editMode, setEditMode] = useState("");
-  const [formData, setFormData] = useState<MessageBackend>({
-    id: "",
-    messageScope: "all",
-    title: "",
-    content: "",
-    postDate: "",
-    postTime: "",
-    deleteDate: "",
-    deleteTime: "",
-    isActive: false,
-  });
+interface MessageAccordionProps {
+  messages: MessageUI[];
+  isLoading: boolean;
+  error: boolean;
+  editingId: string;
+  formData: MessageBackend;
+  startEdit: (msg: MessageUI) => void;
+  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  saveEdit: (id: string) => void;
+  cancelEdit: () => void;
+}
 
-  const handleEdit = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    e.preventDefault();
-
-    setFormData((prev) => ({
-      ...prev,
-      [name]: value,
-    }));
-  };
-
-  const handleSave = (id: string) => {
-    setMockData((prev) =>
-      prev.map((msg) => {
-        if (msg.id === id) {
-          return {
-            ...msg,
-            title: formData.title,
-            content: formData.content,
-          };
-        } else {
-          return msg;
-        }
-      }),
-    );
-    setEditMode("");
-  };
+export const MessageAccordion = ({
+  messages,
+  isLoading,
+  error,
+  editingId,
+  formData,
+  startEdit,
+  handleChange,
+  saveEdit,
+  cancelEdit,
+}: MessageAccordionProps) => {
+  if (isLoading) return <Typography>Loading messages...</Typography>;
+  if (error)
+    return <Typography color="error">Error loading messages</Typography>;
 
   return (
     <Box
@@ -108,7 +70,7 @@ export const MessageAccordion = () => {
     >
       <Typography variant="h5">Messages</Typography>
 
-      {mockData.map((msg) => (
+      {messages.map((msg) => (
         <Accordion key={msg.id} component="form">
           <AccordionSummary
             expandIcon={<ExpandMoreIcon />}
@@ -123,18 +85,25 @@ export const MessageAccordion = () => {
               width={1}
               marginRight={2}
             >
-              {editMode === msg.id ? (
+              {editingId === msg.id ? (
                 <>
                   <TextField
                     label="Title"
                     name="title"
                     fullWidth
                     value={formData.title}
-                    onChange={handleEdit}
+                    onChange={handleChange}
                   />
                   <Button
                     onClick={() => {
-                      handleSave(msg.id);
+                      cancelEdit();
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    onClick={() => {
+                      saveEdit(msg.id);
                     }}
                   >
                     Save
@@ -155,7 +124,7 @@ export const MessageAccordion = () => {
             </Stack>
           </AccordionSummary>
           <AccordionDetails>
-            {editMode === msg.id ? (
+            {editingId === msg.id ? (
               <TextField
                 label="Content"
                 name="content"
@@ -163,7 +132,7 @@ export const MessageAccordion = () => {
                 rows={4}
                 fullWidth
                 value={formData.content}
-                onChange={handleEdit}
+                onChange={handleChange}
               />
             ) : (
               <>
@@ -182,18 +151,13 @@ export const MessageAccordion = () => {
                       {msg.status} {msg.postDateTime}
                     </Typography>
                     <Typography component="span" sx={badgeStyle("delete")}>
-                      Delets {msg.deleteDateTime}
+                      Delets {msg.expiresAtDateTime}
                     </Typography>
                   </Stack>
                   <Stack direction="row" spacing={2}>
                     <Button
                       onClick={() => {
-                        setEditMode(msg.id);
-                        setFormData((prev) => ({
-                          ...prev,
-                          title: msg.title,
-                          content: msg.content,
-                        }));
+                        startEdit(msg);
                       }}
                     >
                       Edit

--- a/frontend/src/components/admin/RoomsAccordion.tsx
+++ b/frontend/src/components/admin/RoomsAccordion.tsx
@@ -16,6 +16,7 @@ import type { Room } from "../../types/types";
 const mockRooms: Room[] = [
   {
     id: "1",
+    bookingId: "60000000-0000-0000-0000-000000000001",
     number: 101,
     status: "occupied",
     title: "Mr",
@@ -25,6 +26,7 @@ const mockRooms: Room[] = [
   },
   {
     id: "2",
+    bookingId: "60000000-0000-0000-0000-000000000002",
     number: 102,
     status: "occupied",
     title: "Mx",
@@ -34,6 +36,7 @@ const mockRooms: Room[] = [
   },
   {
     id: "3",
+    bookingId: "60000000-0000-0000-0000-0000000000013",
     number: 103,
     status: "occupied",
     title: "Ms",
@@ -43,6 +46,7 @@ const mockRooms: Room[] = [
   },
   {
     id: "4",
+    bookingId: "",
     number: 104,
     status: "available",
     title: null,
@@ -91,14 +95,19 @@ export const RoomsAccordion = () => {
                 alignItems="center"
                 sx={{ flex: 1 }}
               >
-                <Typography component="span" fontWeight="600">{room.number}</Typography>
+                <Typography component="span" fontWeight="600">
+                  {room.number}
+                </Typography>
                 {room.status === "occupied" && (
                   <Typography variant="body2">
                     {room.guestFirstName} {room.guestLastName}
                   </Typography>
                 )}
               </Stack>
-              <Button component={NavLink} to={`/admin/rooms/${room.id}`}>
+              <Button
+                component={NavLink}
+                to={`/admin/rooms/${room.id}/${room.bookingId}`}
+              >
                 Edit Room
               </Button>
             </Stack>
@@ -110,9 +119,7 @@ export const RoomsAccordion = () => {
               alignItems="flex-start"
               paddingTop={1}
             >
-              <Typography>
-                Departing Flight: {room.flight}
-              </Typography>
+              <Typography>Departing Flight: {room.flight}</Typography>
             </Stack>
           </AccordionDetails>
         </Accordion>

--- a/frontend/src/components/admin/forms/DashboardForm.tsx
+++ b/frontend/src/components/admin/forms/DashboardForm.tsx
@@ -1,13 +1,18 @@
 import {
   Box,
   Button,
+  FormControlLabel,
   MenuItem,
   Stack,
+  Switch,
   TextField,
   Typography,
 } from "@mui/material";
 import { MessageBaseForm } from "./MessageBaseForm";
 import type { Staff } from "../../../types/types";
+import React, { useState } from "react";
+import { Dayjs } from "dayjs";
+import type { MessageBackend } from "../../../types/message.types";
 
 const mockStaff: Staff[] = [
   { name: "Emmi Quirin" },
@@ -15,7 +20,82 @@ const mockStaff: Staff[] = [
   { name: "Nikita Sjölander" },
 ];
 
-export const DashboardForm = () => {
+interface DashboardFormData extends Omit<
+  MessageBackend,
+  "postAt" | "expiresAt" | "id" | "isActive"
+> {
+  postDate: Dayjs | null;
+  postTime: Dayjs | null;
+  expiresTime: Dayjs | null;
+  expiresDate: Dayjs | null;
+}
+
+interface DashboardFormProps {
+  onSubmit: (formData: MessageBackend) => void;
+}
+
+export const DashboardForm = ({ onSubmit }: DashboardFormProps) => {
+  const [formData, setFormData] = useState<DashboardFormData>({
+    hotelId: import.meta.env.VITE_HOTEL_ID,
+    bookingId: null,
+    title: "",
+    content: "",
+    recurring: false,
+    postDate: null,
+    postTime: null,
+    expiresTime: null,
+    expiresDate: null,
+    author: "",
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const onPostDateChange = (value: Dayjs | null) => {
+    setFormData((prev) => ({ ...prev, postDate: value }));
+  };
+  const onPostTimeChange = (value: Dayjs | null) => {
+    setFormData((prev) => ({ ...prev, postTime: value }));
+  };
+  const onExpiresDateChange = (value: Dayjs | null) => {
+    setFormData((prev) => ({ ...prev, expiresDate: value }));
+  };
+  const onExpiresTimeChange = (value: Dayjs | null) => {
+    setFormData((prev) => ({ ...prev, expiresTime: value }));
+  };
+
+  const handleSubmit = (e: React.SubmitEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    onSubmit({
+      id: "",
+      bookingId: null,
+      hotelId: import.meta.env.VITE_HOTEL_ID,
+      title: formData.title,
+      content: formData.content,
+      isActive: true,
+      recurring: formData.recurring,
+      postAt: formData.postDate
+        ? formData.postDate
+            .set("hour", formData.postTime?.hour() ?? 0)
+            .set("minute", formData.postTime?.minute() ?? 0)
+            .toISOString()
+        : null,
+      expiresAt: formData.expiresDate
+        ? formData.expiresDate
+            .set("hour", formData.expiresTime?.hour() ?? 0)
+            .set("minute", formData.expiresTime?.minute() ?? 0)
+            .toISOString()
+        : null,
+      author: formData.author,
+    });
+  };
+
   return (
     <Box
       component="form"
@@ -26,25 +106,49 @@ export const DashboardForm = () => {
         boxShadow: 1,
         background: "white",
       }}
+      onSubmit={handleSubmit}
     >
       <Typography variant="h5" mb={3}>
         Post Message
       </Typography>
       <Stack spacing={3}>
-        <TextField select label="Send to" name="group" required fullWidth>
-          <MenuItem value="all">All residents</MenuItem>
-          <MenuItem value="checkin">Checking in today</MenuItem>
-          <MenuItem value="checkout">Checking out today</MenuItem>
-        </TextField>
-        <MessageBaseForm />
-        <TextField select label="Author" name="author" required fullWidth>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={formData.recurring}
+              onChange={handleChange}
+              name="Reacurring"
+            />
+          }
+          label="Reacurring"
+        />
+        <MessageBaseForm
+          handleChange={handleChange}
+          onPostTimeChange={onPostTimeChange}
+          onPostDateChange={onPostDateChange}
+          onExpiresTimeChange={onExpiresTimeChange}
+          onExpiresDateChange={onExpiresDateChange}
+          title={formData.title}
+          content={formData.content}
+        />
+        <TextField
+          select
+          label="Author"
+          name="author"
+          value={formData.author}
+          onChange={handleChange}
+          required
+          fullWidth
+        >
           {mockStaff.map((staff, index) => (
             <MenuItem key={index} value={staff.name}>
               {staff.name}
             </MenuItem>
           ))}
         </TextField>
-        <Button variant="contained">Post</Button>
+        <Button variant="contained" type="submit">
+          Post
+        </Button>
       </Stack>
     </Box>
   );

--- a/frontend/src/components/admin/forms/MessageBaseForm.tsx
+++ b/frontend/src/components/admin/forms/MessageBaseForm.tsx
@@ -1,18 +1,69 @@
 import { Box, TextField } from "@mui/material";
 import { DatePicker, TimePicker } from "@mui/x-date-pickers";
+import type { Dayjs } from "dayjs";
+import type React from "react";
 
-export const MessageBaseForm = () => {
+interface MessageBaseFormProps {
+  title: string;
+  content: string;
+  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onPostDateChange: (value: Dayjs | null) => void;
+  onPostTimeChange: (value: Dayjs | null) => void;
+  onExpiresDateChange: (value: Dayjs | null) => void;
+  onExpiresTimeChange: (value: Dayjs | null) => void;
+}
+
+export const MessageBaseForm = ({
+  handleChange,
+  title,
+  content,
+  onPostDateChange,
+  onPostTimeChange,
+  onExpiresDateChange,
+  onExpiresTimeChange,
+}: MessageBaseFormProps) => {
   return (
     <>
-      <TextField label="Title" name="title" fullWidth required />
-      <TextField label="Message" name="message" multiline rows={4} required />
+      <TextField
+        label="Title"
+        name="title"
+        value={title}
+        onChange={handleChange}
+        fullWidth
+        required
+      />
+      <TextField
+        label="Message"
+        name="content"
+        value={content}
+        onChange={handleChange}
+        multiline
+        rows={4}
+        required
+      />
       <Box sx={{ display: "flex", gap: 3 }}>
-        <DatePicker label="Post date" sx={{ flex: 1 }} />
-        <TimePicker label="Post time" sx={{ flex: 1 }} />
+        <DatePicker
+          label="Post date"
+          onChange={onPostDateChange}
+          sx={{ flex: 1 }}
+        />
+        <TimePicker
+          label="Post time"
+          onChange={onPostTimeChange}
+          sx={{ flex: 1 }}
+        />
       </Box>
       <Box sx={{ display: "flex", gap: 3 }}>
-        <DatePicker label="Delete date" sx={{ flex: 1 }} />
-        <TimePicker label="Delete time" sx={{ flex: 1 }} />
+        <DatePicker
+          label="Delete date"
+          onChange={onExpiresDateChange}
+          sx={{ flex: 1 }}
+        />
+        <TimePicker
+          label="Delete time"
+          onChange={onExpiresTimeChange}
+          sx={{ flex: 1 }}
+        />
       </Box>
     </>
   );

--- a/frontend/src/components/admin/forms/RoomDetailsForm.tsx
+++ b/frontend/src/components/admin/forms/RoomDetailsForm.tsx
@@ -13,6 +13,7 @@ import { AdditionalGuestList } from "../AdditionalGuestList";
 import type { AdditionalGuest } from "../../../types/types";
 
 interface GuestFormData {
+  bookingId: string | null;
   firstName: string;
   lastName: string;
   title: string;
@@ -21,9 +22,14 @@ interface GuestFormData {
   additionalGuests: AdditionalGuest[];
 }
 
-export const RoomDetailsForm = () => {
+interface RoomDetailsParams {
+  bookingId?: string | null;
+}
+
+export const RoomDetailsForm = ({ bookingId }: RoomDetailsParams) => {
   const [editMode, setEditMode] = useState(false);
   const [formData, setFormData] = useState<GuestFormData>({
+    bookingId: bookingId ?? null,
     firstName: "",
     lastName: "",
     title: "",
@@ -56,94 +62,119 @@ export const RoomDetailsForm = () => {
         Room Details
       </Typography>
       <Stack>
-        <Typography variant="body2">First Name:</Typography>
-        {editMode ? (
-          <TextField
-            name="firstName"
-            value={formData.firstName}
-            onChange={handleChange}
-            fullWidth
-            required
-            sx={{ mt: 1 }}
-          />
-        ) : (
-          <Typography sx={{ mt: 1, fontWeight: 600 }} variant="body1">
-            {formData.firstName}
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Typography variant="body2" sx={{ flexShrink: 0 }}>
+            Booking Id:{" "}
           </Typography>
-        )}
-        <Typography sx={{ mt: 3 }} variant="body2">
-          Last Name:
-        </Typography>
-        {editMode ? (
-          <TextField
-            sx={{ mt: 1 }}
-            name="lastName"
-            value={formData.lastName}
-            onChange={handleChange}
-            fullWidth
-            required
-          />
-        ) : (
-          <Typography sx={{ mt: 1, fontWeight: 600 }} variant="body1">
-            {formData.lastName}
+          {formData.bookingId ? (
+            <Typography sx={{ mt: 1, fontWeight: 600 }} variant="body1">
+              {formData.bookingId}
+            </Typography>
+          ) : (
+            ""
+          )}
+        </Stack>
+        <Stack direction="row" spacing={2} alignItems="center" sx={{ mt: 3 }}>
+          <Typography variant="body2" sx={{ flexShrink: 0 }}>
+            First Name:
           </Typography>
-        )}
-        <Typography sx={{ mt: 3 }} variant="body2">
-          Title:
-        </Typography>
-        {editMode ? (
-          <TextField
-            select
-            name="title"
-            value={formData.title}
-            onChange={handleChange}
-            required
-            fullWidth
-            sx={{ mt: 1 }}
-          >
-            <MenuItem value="Mx">Mx</MenuItem>
-            <MenuItem value="Mr">Mr</MenuItem>
-            <MenuItem value="Mrs">Mrs</MenuItem>
-            <MenuItem value="Ms">Ms</MenuItem>
-          </TextField>
-        ) : (
-          <Typography sx={{ mt: 1, fontWeight: 600 }} variant="body1">
-            {formData.title}
+          {editMode ? (
+            <TextField
+              name="firstName"
+              value={formData.firstName}
+              onChange={handleChange}
+              fullWidth
+              required
+              sx={{ mt: 1 }}
+            />
+          ) : (
+            <Typography sx={{ mt: 1, fontWeight: 600 }} variant="body1">
+              {formData.firstName}
+            </Typography>
+          )}
+        </Stack>
+        <Stack direction="row" spacing={2} alignItems="center" sx={{ mt: 3 }}>
+          <Typography sx={{ flexShrink: 0 }} variant="body2">
+            Last Name:
           </Typography>
-        )}
-        <Typography sx={{ mt: 3 }} variant="body2">
-          Depature Flight:
-        </Typography>
-        {editMode ? (
-          <TextField
-            name="departureFligth"
-            value={formData.departureFligth}
-            onChange={handleChange}
-            fullWidth
-            required
-            sx={{ mt: 1 }}
-          />
-        ) : (
-          <Typography sx={{ mt: 1, fontWeight: 600 }} variant="body1">
-            {formData.departureFligth}
+          {editMode ? (
+            <TextField
+              sx={{ mt: 1 }}
+              name="lastName"
+              value={formData.lastName}
+              onChange={handleChange}
+              fullWidth
+              required
+            />
+          ) : (
+            <Typography sx={{ mt: 1, fontWeight: 600 }} variant="body1">
+              {formData.lastName}
+            </Typography>
+          )}
+        </Stack>
+        <Stack direction="row" spacing={2} alignItems="center" sx={{ mt: 3 }}>
+          <Typography sx={{ flexShrink: 0 }} variant="body2">
+            Title:
           </Typography>
-        )}
-        <Typography sx={{ mt: 3 }} variant="body2">
-          Departure Date:
-        </Typography>
-        {editMode ? (
-          <DatePicker
-            name="departureDate"
-            // value={formData.departureDate}
-            // onChange={handleChange}
-            label="Departure date"
-            sx={{ mt: 1 }}
-          />
-        ) : (
-          <Typography sx={{ mt: 1, fontWeight: 600 }} variant="body1">
-            {formData.departureFligth}
+          {editMode ? (
+            <TextField
+              select
+              name="title"
+              value={formData.title}
+              onChange={handleChange}
+              required
+              fullWidth
+              sx={{ mt: 1 }}
+            >
+              <MenuItem value="Mx">Mx</MenuItem>
+              <MenuItem value="Mr">Mr</MenuItem>
+              <MenuItem value="Mrs">Mrs</MenuItem>
+              <MenuItem value="Ms">Ms</MenuItem>
+            </TextField>
+          ) : (
+            <Typography sx={{ mt: 1, fontWeight: 600 }} variant="body1">
+              {formData.title}
+            </Typography>
+          )}
+        </Stack>
+        <Stack direction="row" spacing={2} alignItems="center" sx={{ mt: 3 }}>
+          <Typography sx={{ flexShrink: 0 }} variant="body2">
+            Depature Flight:
           </Typography>
-        )}
+          {editMode ? (
+            <TextField
+              name="departureFligth"
+              value={formData.departureFligth}
+              onChange={handleChange}
+              fullWidth
+              required
+              sx={{ mt: 1 }}
+            />
+          ) : (
+            <Typography sx={{ mt: 1, fontWeight: 600 }} variant="body1">
+              {formData.departureFligth}
+            </Typography>
+          )}
+        </Stack>
+        <Stack direction="row" spacing={2} alignItems="center" sx={{ mt: 3 }}>
+          <Typography sx={{ flexShrink: 0 }} variant="body2">
+            Departure Date:
+          </Typography>
+          {editMode ? (
+            <DatePicker
+              name="departureDate"
+              // value={formData.departureDate}
+              // onChange={handleChange}
+              label="Departure date"
+              sx={{ mt: 1 }}
+            />
+          ) : (
+            <Typography sx={{ mt: 1, fontWeight: 600 }} variant="body1">
+              {formData.departureFligth}
+            </Typography>
+          )}
+        </Stack>
+
         {editMode ? (
           <>
             <AdditionalGuestFields />
@@ -151,7 +182,7 @@ export const RoomDetailsForm = () => {
           </>
         ) : (
           <>
-            <Typography sx={{ mt: 3 }} variant="body2">
+            <Typography sx={{ flexShrink: 0, mt: 3 }} variant="body2">
               Additional Guest(s)
             </Typography>
             <AdditionalGuestList guests={formData.additionalGuests} />

--- a/frontend/src/components/admin/forms/RoomMessageForm.tsx
+++ b/frontend/src/components/admin/forms/RoomMessageForm.tsx
@@ -1,7 +1,85 @@
 import { Box, Button, Stack, Typography } from "@mui/material";
 import { MessageBaseForm } from "./MessageBaseForm";
+import { useState } from "react";
+import type { Dayjs } from "dayjs";
+import type { MessageBackend } from "../../../types/message.types";
 
-export const RoomMessageForm = () => {
+interface RoomFormData extends Omit<
+  MessageBackend,
+  "postAt" | "expiresAt" | "id" | "isActive"
+> {
+  postDate: Dayjs | null;
+  postTime: Dayjs | null;
+  expiresTime: Dayjs | null;
+  expiresDate: Dayjs | null;
+}
+interface RoomFormProps {
+  onSubmit: (formData: MessageBackend) => void;
+  bookingId?: string | null;
+}
+
+export const RoomMessageForm = ({ onSubmit, bookingId }: RoomFormProps) => {
+  const [formData, setFormData] = useState<RoomFormData>({
+    hotelId: import.meta.env.VITE_HOTEL_ID,
+    bookingId: bookingId ? bookingId : null,
+    title: "",
+    content: "",
+    recurring: false,
+    postDate: null,
+    postTime: null,
+    expiresTime: null,
+    expiresDate: null,
+    author: "",
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const onPostDateChange = (value: Dayjs | null) => {
+    setFormData((prev) => ({ ...prev, postDate: value }));
+  };
+  const onPostTimeChange = (value: Dayjs | null) => {
+    setFormData((prev) => ({ ...prev, postTime: value }));
+  };
+  const onExpiresDateChange = (value: Dayjs | null) => {
+    setFormData((prev) => ({ ...prev, expiresDate: value }));
+  };
+  const onExpiresTimeChange = (value: Dayjs | null) => {
+    setFormData((prev) => ({ ...prev, expiresTime: value }));
+  };
+
+  const handleSubmit = (e: React.SubmitEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    onSubmit({
+      id: "",
+      bookingId: formData.bookingId,
+      hotelId: import.meta.env.VITE_HOTEL_ID,
+      title: formData.title,
+      content: formData.content,
+      isActive: true,
+      recurring: false,
+      postAt: formData.postDate
+        ? formData.postDate
+            .set("hour", formData.postTime?.hour() ?? 0)
+            .set("minute", formData.postTime?.minute() ?? 0)
+            .toISOString()
+        : null,
+      expiresAt: formData.expiresDate
+        ? formData.expiresDate
+            .set("hour", formData.expiresTime?.hour() ?? 0)
+            .set("minute", formData.expiresTime?.minute() ?? 0)
+            .toISOString()
+        : null,
+      author: formData.author,
+    });
+  };
+
   return (
     <Box
       component="form"
@@ -12,13 +90,24 @@ export const RoomMessageForm = () => {
         boxShadow: 1,
         background: "white",
       }}
+      onSubmit={handleSubmit}
     >
       <Typography variant="h5" mb={3}>
         Message
       </Typography>
       <Stack spacing={3}>
-        <MessageBaseForm />
-        <Button variant="contained">Post</Button>
+        <MessageBaseForm
+          handleChange={handleChange}
+          onPostTimeChange={onPostTimeChange}
+          onPostDateChange={onPostDateChange}
+          onExpiresTimeChange={onExpiresTimeChange}
+          onExpiresDateChange={onExpiresDateChange}
+          title={formData.title}
+          content={formData.content}
+        />
+        <Button variant="contained" type="submit">
+          Post
+        </Button>
       </Stack>
     </Box>
   );

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export { useWeather } from "./useWeather";
-export { useFlightInfo } from "./useFlightInfo"
+export { useFlightInfo } from "./useFlightInfo";
+export { useMessages } from "./useMessages";
 
-export { useDepartureFlights } from "./useDepartureFlights"
-export { useArrivalFlights } from "./useArrivalFlights"
+export { useDepartureFlights } from "./useDepartureFlights";
+export { useArrivalFlights } from "./useArrivalFlights";

--- a/frontend/src/hooks/useMessages.ts
+++ b/frontend/src/hooks/useMessages.ts
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from "react";
+import type { MessageBackend, MessageUI } from "../types/message.types";
+import { getMessages } from "../services/api/getMessages";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { postMessage } from "../services/api/postMessage";
+
+type UseMessageAccordionParams = {
+  initialMessages?: MessageUI[];
+  hotelId: string;
+  bookingId?: string;
+};
+
+// Websocket??
+
+export const useMessages = ({
+  initialMessages = [],
+  bookingId,
+}: UseMessageAccordionParams) => {
+  const queryClient = useQueryClient();
+  const {
+    data = initialMessages,
+    isLoading,
+    isPending,
+    error,
+  } = useQuery<MessageUI[]>({
+    queryKey: ["messages", bookingId],
+    queryFn: () => getMessages({ bookingId }),
+    enabled: !!initialMessages,
+    // staleTime: 2 * 5 * 1000,
+  });
+
+  const { mutate } = useMutation<string, Error, MessageBackend>({
+    mutationFn: postMessage,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["messages", bookingId] });
+    },
+  });
+
+  const onSubmit = (formData: MessageBackend) => {
+    mutate(formData);
+  };
+
+  const [messages, setMessages] = useState<MessageUI[]>(data);
+  const [editingId, setEditingId] = useState("");
+  const [formData, setFormData] = useState<MessageBackend>({
+    id: "",
+    bookingId: null,
+    hotelId: import.meta.env.VITE_HOTEL_ID,
+    title: "",
+    content: "",
+    recurring: false,
+    postAt: null,
+    expiresAt: null,
+    isActive: false,
+    author: "",
+  });
+
+  useEffect(() => {
+    setMessages(data);
+  }, [data]);
+
+  const startEdit = (msg: MessageUI) => {
+    setEditingId(msg.id);
+
+    setFormData((prev) => ({
+      ...prev,
+      id: msg.id,
+      title: msg.title,
+      content: msg.content,
+    }));
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    e.preventDefault();
+
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const saveEdit = (id: string) => {
+    setMessages((prev) =>
+      prev.map((msg) => {
+        if (msg.id === id) {
+          return {
+            ...msg,
+            title: formData.title,
+            content: formData.content,
+          };
+        } else {
+          return msg;
+        }
+      }),
+    );
+    setEditingId("");
+  };
+
+  const cancelEdit = () => {
+    setEditingId("");
+  };
+
+  return {
+    messages,
+    isLoading,
+    isPending,
+    error,
+    editingId,
+    formData,
+    startEdit,
+    saveEdit,
+    cancelEdit,
+    handleChange,
+    onSubmit,
+  };
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -26,6 +26,10 @@ const Main = () => {
                 <Route index element={<AdminHome />} />
                 <Route path="rooms" element={<RoomAdminPage />} />
                 <Route path="rooms/:id" element={<RoomDetailsPage />} />
+                <Route
+                  path="rooms/:id/:bookingId"
+                  element={<RoomDetailsPage />}
+                />
                 <Route path="settings" element={<SettingsPage />} />
               </Route>
               <Route path="/room/:id" element={<Room />}></Route>

--- a/frontend/src/pages/admin/AdminHome.tsx
+++ b/frontend/src/pages/admin/AdminHome.tsx
@@ -2,15 +2,41 @@ import { DashboardForm } from "../../components/admin/forms/DashboardForm";
 import Watch from "../../components/base/watch";
 import { Stack, Typography } from "@mui/material";
 import { MessageAccordion } from "../../components/admin/MessageAccordion";
+import { useMessages } from "../../hooks";
+
+const hotelId = import.meta.env.VITE_HOTEL_ID;
 
 export default function AdminHome() {
+  const {
+    messages,
+    isLoading,
+    error,
+    editingId,
+    formData,
+    startEdit,
+    handleChange,
+    saveEdit,
+    cancelEdit,
+    onSubmit
+  } = useMessages({ hotelId });
+
   return (
     <>
       <Typography variant="h2">DashyBoard</Typography>
       <Watch location="Stockholm" timeZone="UTC"></Watch>
       <Stack direction="row" spacing={2} alignItems="flex-start">
-        <DashboardForm />
-        <MessageAccordion />
+        <DashboardForm onSubmit={onSubmit} />
+        <MessageAccordion
+          messages={messages}
+          editingId={editingId}
+          isLoading={isLoading}
+          error={!!error}
+          formData={formData}
+          startEdit={startEdit}
+          handleChange={handleChange}
+          saveEdit={saveEdit}
+          cancelEdit={cancelEdit}
+        />
       </Stack>
     </>
   );

--- a/frontend/src/pages/admin/RoomDetails.tsx
+++ b/frontend/src/pages/admin/RoomDetails.tsx
@@ -5,10 +5,25 @@ import { Button, Stack, Typography } from "@mui/material";
 import { MessageAccordion } from "../../components/admin/MessageAccordion";
 import AlertDialog from "../../components/admin/AlertDialog";
 import React from "react";
+import { useMessages } from "../../hooks";
+
+const hotelId = import.meta.env.VITE_HOTEL_ID;
 
 export default function Room() {
-  const { id } = useParams();
+  const { id, bookingId } = useParams();
   const [dialogOpen, setDialogOpen] = React.useState(false);
+  const {
+    messages,
+    isLoading,
+    error,
+    editingId,
+    formData,
+    startEdit,
+    handleChange,
+    saveEdit,
+    cancelEdit,
+    onSubmit,
+  } = useMessages({ hotelId, bookingId });
 
   const handleDialog = () => {
     setDialogOpen(true);
@@ -36,10 +51,24 @@ export default function Room() {
         </Button>
       </Stack>
       <Stack direction="row" spacing={2} alignItems="flex-start">
-        <RoomDetailsForm />
-        <RoomMessageForm />
+        <RoomDetailsForm bookingId={bookingId} />
+        {bookingId && (
+          <RoomMessageForm onSubmit={onSubmit} bookingId={bookingId} />
+        )}
       </Stack>
-      <MessageAccordion />
+      {bookingId && (
+        <MessageAccordion
+          messages={messages}
+          editingId={editingId}
+          isLoading={isLoading}
+          error={!!error}
+          formData={formData}
+          startEdit={startEdit}
+          handleChange={handleChange}
+          saveEdit={saveEdit}
+          cancelEdit={cancelEdit}
+        />
+      )}
       <AlertDialog open={dialogOpen} onClose={handleClose} />
     </>
   );

--- a/frontend/src/services/api/getMessages.ts
+++ b/frontend/src/services/api/getMessages.ts
@@ -1,0 +1,40 @@
+import { mapMessageFromApi } from "../../api/message.adapter";
+import type { MessageUI } from "../../types/message.types";
+
+interface GetMessagesProps {
+  bookingId?: string;
+}
+
+export async function getMessages({
+  bookingId,
+}: GetMessagesProps): Promise<MessageUI[]> {
+  const apiUrl = import.meta.env.VITE_BASE_URL || "http://localhost:5000";
+  const hotelId = import.meta.env.VITE_HOTEL_ID;
+
+  let res;
+
+  if (bookingId) {
+    res = await fetch(
+      `${apiUrl}/api/messages?hotelId=${hotelId}&bookingId=${bookingId}`,
+      {
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  } else {
+    res = await fetch(`${apiUrl}/api/messages/`, {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (!res.ok) {
+    throw new Error(`Cound't get messages`);
+  }
+
+  const json = await res.json();
+  const items = Array.isArray(json)
+    ? json
+    : (json?.messages ?? json?.data ?? json);
+
+  console.log(items.map(mapMessageFromApi));
+  return items.map(mapMessageFromApi);
+}

--- a/frontend/src/services/api/postMessage.ts
+++ b/frontend/src/services/api/postMessage.ts
@@ -1,0 +1,24 @@
+import type { MessageBackend } from "../../types/message.types";
+
+export async function postMessage(data: MessageBackend) {
+  const apiUrl = import.meta.env.VITE_BASE_URL || "http://localhost:5000";
+
+  console.log(import.meta.env.VITE_HOTEL_ID)
+
+  const res = await fetch(`${apiUrl}/api/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      hotelId: import.meta.env.VITE_HOTEL_ID,
+      bookingId: data.bookingId,
+      content: data.content,
+      expiresAt: data.expiresAt,
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Cound't post messages`);
+  } else {
+    return "Posted";
+  }
+}

--- a/frontend/src/types/message.types.ts
+++ b/frontend/src/types/message.types.ts
@@ -1,26 +1,29 @@
 import type { MsgStatus } from "./theme.types";
 
-export type MessageScope = "all" | "checkingOut" | "checkingIn";
-
-
 export type MessageBackend = {
   id: string;
-  messageScope: MessageScope;
+  hotelId: string;
+  bookingId: string | null;
   title: string;
   content: string;
-  postDate: string | null;
-  postTime: string | null;
-  deleteDate: string | null;
-  deleteTime: string | null;
+  recurring: boolean;
+  postAt: string | null;
+  expiresAt: string | null;
   isActive: boolean;
+  author: string;
 };
+
+// Återkommande meddelanden? bocka i återkommande
 
 export type MessageUI = {
   id: string;
-  messageScope: MessageScope;
+  hotelId: string;
+  bookingId: string | null;
   title: string;
   content: string;
   status: MsgStatus;
   postDateTime: string | null;
-  deleteDateTime: string | null;
-}
+  expiresAtDateTime: string | null;
+  isActive: boolean;
+  author: string;
+};

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -3,6 +3,7 @@ export type Title = "Mrs" | "Ms" | "Mr" | "Mx" | null;
 
 export type Room = {
   id: string;
+  bookingId: string,
   number: number;
   status: RoomStatus;
   title: Title;


### PR DESCRIPTION
**Restructure admin message forms and connect to API**

Refactors the message feature on the admin side to use real API data instead of mock data, and makes all form components controlled.

**Changes:**

- Message forms (DashboardForm, RoomMessageForm, MessageBaseForm) are now controlled with local state and handle submit
- Added getMessages service and useMessages hook using react-query for fetching and edit state
- MessageAccordion now receives messages via the hook instead of inline mock data
- Added postMessage service for creating messages via the API
- Updated MessageBackend/MessageUI types and adapter to match the backend contract (hotelId, bookingId, expiresAt, etc.)
- Added bookingId to the Room type and threads it from RoomsAccordion through to RoomDetailsForm and RoomMessageForm
- Added a route for /admin/rooms/:id/:bookingId